### PR TITLE
Fix issue with `ifLet` where `else` was being called too often (#225)

### DIFF
--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -43,7 +43,8 @@ extension Store {
     then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
     else: @escaping () -> Void
   ) -> Cancellable where State == Wrapped? {
-    let elseCancellable = self
+    let elseCancellable =
+      self
       .scope(
         state: { state in
           state
@@ -54,7 +55,8 @@ extension Store {
         if store.state.value == nil { `else`() }
       }
 
-    let unwrapCancellable = self
+    let unwrapCancellable =
+      self
       .scope(
         state: { state in
           state

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -289,7 +289,8 @@ final class StoreTests: XCTestCase {
         },
         else: {
           outputs.append(nil)
-        })
+        }
+      )
       .store(in: &self.cancellables)
 
     XCTAssertEqual(outputs, [nil])

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -233,4 +233,116 @@ final class StoreTests: XCTestCase {
     store.send(.incr)
     XCTAssertEqual(ViewStore(store).state, 100_000)
   }
+
+  func testPublisherScope() {
+    let appReducer = Reducer<Int, Bool, Void> { state, action, _ in
+      state += action ? 1 : 0
+      return .none
+    }
+
+    let parentStore = Store(initialState: 0, reducer: appReducer, environment: ())
+
+    var outputs: [Int] = []
+
+    parentStore
+      .scope { $0.removeDuplicates() }
+      .sink { outputs.append($0.state.value) }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(outputs, [0])
+
+    parentStore.send(true)
+    XCTAssertEqual(outputs, [0, 1])
+
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+  }
+
+  func testIfLetAfterScope() {
+    struct AppState {
+      var count: Int?
+    }
+
+    let appReducer = Reducer<AppState, Int?, Void> { state, action, _ in
+      state.count = action
+      return .none
+    }
+
+    let parentStore = Store(initialState: AppState(), reducer: appReducer, environment: ())
+
+    // NB: This test needs to hold a strong reference to the emitted stores
+    var outputs: [Int?] = []
+    var stores: [Any] = []
+
+    parentStore
+      .scope(state: { $0.count })
+      .ifLet(
+        then: { store in
+          stores.append(store)
+          outputs.append(store.state.value)
+        },
+        else: {
+          outputs.append(nil)
+        })
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(outputs, [nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1, nil])
+  }
+
+  func testIfLetTwo() {
+    let parentStore = Store(
+      initialState: 0,
+      reducer: Reducer<Int?, Bool, Void> { state, action, _ in
+        if action {
+          state? += 1
+          return .none
+        } else {
+          return Just(true).receive(on: DispatchQueue.main).eraseToEffect()
+        }
+      },
+      environment: ()
+    )
+
+    parentStore.ifLet { childStore in
+      let vs = ViewStore(childStore)
+
+      vs
+        .publisher
+        .sink { _ in }
+        .store(in: &self.cancellables)
+
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      XCTAssertEqual(vs.state, 3)
+    }
+    .store(in: &self.cancellables)
+  }
 }


### PR DESCRIPTION
* Fixes issue with ifLet where `else` was being called too often.

* Remove debug printing.

* Attempt to fix compile issue on Xcode 11.3